### PR TITLE
Add clear API

### DIFF
--- a/adapters/controllers/album.go
+++ b/adapters/controllers/album.go
@@ -11,15 +11,18 @@ type AlbumControllerExt interface {
 	GetAll(c *gin.Context)
 	GetById(c *gin.Context)
 	Post(c *gin.Context)
+	Clear(c *gin.Context)
 }
 
 type albumController struct {
-	aau   usecases.AlbumAllUsecaseExt
-	aap   presenters.AlbumAllPresenterExt
-	agbiu usecases.AlbumGetByIDUsecaseExt
-	agbip presenters.AlbumGetByIDPresenterExt
-	acu   usecases.AlbumCreateUsecaseExt
-	acp   presenters.AlbumCreatePresenterExt
+	aau           usecases.AlbumAllUsecaseExt
+	aap           presenters.AlbumAllPresenterExt
+	agbiu         usecases.AlbumGetByIDUsecaseExt
+	agbip         presenters.AlbumGetByIDPresenterExt
+	acu           usecases.AlbumCreateUsecaseExt
+	acp           presenters.AlbumCreatePresenterExt
+	albumClearUse usecases.AlbumClearUsecaseExt
+	albumClearPre presenters.AlbumClearPresenterExt
 }
 
 func NewAlbumController(
@@ -29,15 +32,19 @@ func NewAlbumController(
 	agbip presenters.AlbumGetByIDPresenterExt,
 	acu usecases.AlbumCreateUsecaseExt,
 	acp presenters.AlbumCreatePresenterExt,
+	albumClearUse usecases.AlbumClearUsecaseExt,
+	albumClearPre presenters.AlbumClearPresenterExt,
 ) AlbumControllerExt {
 
 	return &albumController{
-		aau:   aau,
-		aap:   aap,
-		agbiu: agbiu,
-		agbip: agbip,
-		acu:   acu,
-		acp:   acp,
+		aau:           aau,
+		aap:           aap,
+		agbiu:         agbiu,
+		agbip:         agbip,
+		acu:           acu,
+		acp:           acp,
+		albumClearUse: albumClearUse,
+		albumClearPre: albumClearPre,
 	}
 }
 
@@ -93,6 +100,22 @@ func (h *albumController) Post(c *gin.Context) {
 	}
 
 	pRes, err := h.acp.Response(cRes)
+	if err != nil {
+		ResponseError(c, err)
+		return
+	}
+
+	c.JSON(200, pRes.Res)
+}
+
+func (h *albumController) Clear(c *gin.Context) {
+	cRes, err := h.albumClearUse.Clear(c)
+	if err != nil {
+		ResponseError(c, err)
+		return
+	}
+
+	pRes, err := h.albumClearPre.Response(cRes)
 	if err != nil {
 		ResponseError(c, err)
 		return

--- a/adapters/controllers/artist.go
+++ b/adapters/controllers/artist.go
@@ -11,15 +11,18 @@ type ArtistControllerExt interface {
 	GetAll(c *gin.Context)
 	GetById(c *gin.Context)
 	Post(c *gin.Context)
+	Clear(c *gin.Context)
 }
 
 type artistController struct {
-	aau   usecases.ArtistAllUsecaseExt
-	aap   presenters.ArtistAllPresenterExt
-	agbiu usecases.ArtistGetByIDUsecaseExt
-	agbip presenters.ArtistGetByIDPresenterExt
-	acu   usecases.ArtistCreateUsecaseExt
-	acp   presenters.ArtistCreatePresenterExt
+	aau            usecases.ArtistAllUsecaseExt
+	aap            presenters.ArtistAllPresenterExt
+	agbiu          usecases.ArtistGetByIDUsecaseExt
+	agbip          presenters.ArtistGetByIDPresenterExt
+	acu            usecases.ArtistCreateUsecaseExt
+	acp            presenters.ArtistCreatePresenterExt
+	artistClearUse usecases.ArtistClearUsecaseExt
+	artistClearPre presenters.ArtistClearPresenterExt
 }
 
 func NewArtistController(
@@ -29,15 +32,19 @@ func NewArtistController(
 	agbip presenters.ArtistGetByIDPresenterExt,
 	acu usecases.ArtistCreateUsecaseExt,
 	acp presenters.ArtistCreatePresenterExt,
+	artistClearUse usecases.ArtistClearUsecaseExt,
+	artistClearPre presenters.ArtistClearPresenterExt,
 ) ArtistControllerExt {
 
 	return &artistController{
-		aau:   aau,
-		aap:   aap,
-		agbiu: agbiu,
-		agbip: agbip,
-		acu:   acu,
-		acp:   acp,
+		aau:            aau,
+		aap:            aap,
+		agbiu:          agbiu,
+		agbip:          agbip,
+		acu:            acu,
+		acp:            acp,
+		artistClearUse: artistClearUse,
+		artistClearPre: artistClearPre,
 	}
 }
 
@@ -93,6 +100,22 @@ func (h *artistController) Post(c *gin.Context) {
 	}
 
 	pRes, err := h.acp.Response(cRes)
+	if err != nil {
+		ResponseError(c, err)
+		return
+	}
+
+	c.JSON(200, pRes.Res)
+}
+
+func (h *artistController) Clear(c *gin.Context) {
+	cRes, err := h.artistClearUse.Clear(c)
+	if err != nil {
+		ResponseError(c, err)
+		return
+	}
+
+	pRes, err := h.artistClearPre.Response(cRes)
 	if err != nil {
 		ResponseError(c, err)
 		return

--- a/adapters/controllers/song.go
+++ b/adapters/controllers/song.go
@@ -11,15 +11,18 @@ type SongControllerExt interface {
 	GetAll(c *gin.Context)
 	GetById(c *gin.Context)
 	Post(c *gin.Context)
+	Clear(c *gin.Context)
 }
 
 type songController struct {
-	sau   usecases.SongAllUsecaseExt
-	sap   presenters.SongAllPresenterExt
-	sgbiu usecases.SongGetByIDUsecaseExt
-	sgbip presenters.SongGetByIDPresenterExt
-	scu   usecases.SongCreateUsecaseExt
-	scp   presenters.SongCreatePresenterExt
+	sau          usecases.SongAllUsecaseExt
+	sap          presenters.SongAllPresenterExt
+	sgbiu        usecases.SongGetByIDUsecaseExt
+	sgbip        presenters.SongGetByIDPresenterExt
+	scu          usecases.SongCreateUsecaseExt
+	scp          presenters.SongCreatePresenterExt
+	songClearUse usecases.SongClearUsecaseExt
+	songClearPre presenters.SongClearPresenterExt
 }
 
 func NewSongController(
@@ -29,15 +32,19 @@ func NewSongController(
 	sgbip presenters.SongGetByIDPresenterExt,
 	scu usecases.SongCreateUsecaseExt,
 	scp presenters.SongCreatePresenterExt,
+	songClearUse usecases.SongClearUsecaseExt,
+	songClearPre presenters.SongClearPresenterExt,
 ) SongControllerExt {
 
 	return &songController{
-		sau:   sau,
-		sap:   sap,
-		sgbiu: sgbiu,
-		sgbip: sgbip,
-		scu:   scu,
-		scp:   scp,
+		sau:          sau,
+		sap:          sap,
+		sgbiu:        sgbiu,
+		sgbip:        sgbip,
+		scu:          scu,
+		scp:          scp,
+		songClearUse: songClearUse,
+		songClearPre: songClearPre,
 	}
 }
 
@@ -93,6 +100,22 @@ func (h *songController) Post(c *gin.Context) {
 	}
 
 	pRes, err := h.scp.Response(cRes)
+	if err != nil {
+		ResponseError(c, err)
+		return
+	}
+
+	c.JSON(200, pRes.Res)
+}
+
+func (h *songController) Clear(c *gin.Context) {
+	cRes, err := h.songClearUse.Clear(c)
+	if err != nil {
+		ResponseError(c, err)
+		return
+	}
+
+	pRes, err := h.songClearPre.Response(cRes)
 	if err != nil {
 		ResponseError(c, err)
 		return

--- a/adapters/dbs/album_mysql.go
+++ b/adapters/dbs/album_mysql.go
@@ -38,6 +38,12 @@ func (c *albumMysql) Create(album *models.Album) (uint, error) {
 	return album.ID, err
 }
 
+func (c *albumMysql) Clear() error {
+	err := c.db.Delete(&models.Album{}).Error
+
+	return err
+}
+
 type MixInAlbumMysql struct {
 	albumMysql
 }

--- a/adapters/dbs/album_mysql_test.go
+++ b/adapters/dbs/album_mysql_test.go
@@ -63,3 +63,20 @@ func TestAlbumCreate(t *testing.T) {
 	_, err := ar.Create(expect)
 	assert.NoError(t, err)
 }
+
+func TestAlbumClear(t *testing.T) {
+	db, mock := models.ConnectMockDB("test_album_clear")
+	defer db.Close()
+
+	// ormのdeleteはsoft deleteなので、updateでdelete_atが更新される
+	// このとき、任意のtimeをdelete_atに挿入できないのでテストできない
+	// なので、とりあえず、update命令をキャッチはしているが、argは指定していない
+	mock.ExpectExec("UPDATE").
+		WithArgs().
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	ar := NewAlbumMysql(db)
+
+	err := ar.Clear()
+	assert.NoError(t, err)
+}

--- a/adapters/dbs/artist_mysql.go
+++ b/adapters/dbs/artist_mysql.go
@@ -38,6 +38,12 @@ func (c *artistMysql) Create(artist *models.Artist) (uint, error) {
 	return artist.ID, err
 }
 
+func (c *artistMysql) Clear() error {
+	err := c.db.Delete(&models.Artist{}).Error
+
+	return err
+}
+
 type MixInArtistMysql struct {
 	artistMysql
 }

--- a/adapters/dbs/artist_mysql_test.go
+++ b/adapters/dbs/artist_mysql_test.go
@@ -63,3 +63,20 @@ func TestArtistCreate(t *testing.T) {
 	_, err := ar.Create(expect)
 	assert.NoError(t, err)
 }
+
+func TestArtistClear(t *testing.T) {
+	db, mock := models.ConnectMockDB("test_artist_clear")
+	defer db.Close()
+
+	// ormのdeleteはsoft deleteなので、updateでdelete_atが更新される
+	// このとき、任意のtimeをdelete_atに挿入できないのでテストできない
+	// なので、とりあえず、update命令をキャッチはしているが、argは指定していない
+	mock.ExpectExec("UPDATE").
+		WithArgs().
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	ar := NewArtistMysql(db)
+
+	err := ar.Clear()
+	assert.NoError(t, err)
+}

--- a/adapters/dbs/song_mysql.go
+++ b/adapters/dbs/song_mysql.go
@@ -44,6 +44,12 @@ func (m *songMysql) Create(song *models.Song) (uint, error) {
 	return song.ID, err
 }
 
+func (c *songMysql) Clear() error {
+	err := c.db.Delete(&models.Song{}).Error
+
+	return err
+}
+
 type MixInSongMysql struct {
 	songMysql
 }

--- a/adapters/dbs/song_mysql_test.go
+++ b/adapters/dbs/song_mysql_test.go
@@ -63,3 +63,20 @@ func TestSongCreate(t *testing.T) {
 	_, err := ar.Create(expect)
 	assert.NoError(t, err)
 }
+
+func TestSongClear(t *testing.T) {
+	db, mock := models.ConnectMockDB("test_song_clear")
+	defer db.Close()
+
+	songRepo := NewSongMysql(db)
+
+	// ormのdeleteはsoft deleteなので、updateでdelete_atが更新される
+	// このとき、任意のtimeをdelete_atに挿入できないのでテストできない
+	// なので、とりあえず、update命令をキャッチはしているが、argは指定していない
+	mock.ExpectExec("UPDATE").
+		WithArgs().
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := songRepo.Clear()
+	assert.NoError(t, err)
+}

--- a/adapters/presenters/album_clear.go
+++ b/adapters/presenters/album_clear.go
@@ -1,0 +1,32 @@
+package presenters
+
+import (
+	"encoding/json"
+
+	"github.com/Basabi-lab/lms/usecases"
+)
+
+type AlbumClearPresenterExt interface {
+	Response(useResult *usecases.AlbumClearUsecaseResult) (*AlbumClearPresenterResult, error)
+}
+
+type AlbumClearPresenterResult struct {
+	Res []byte
+}
+
+type albumClearPresenter struct{}
+
+func NewAlbumClearPresenter() AlbumClearPresenterExt {
+	return &albumClearPresenter{}
+}
+
+func NewAlbumClearPresenterResult(json []byte) *AlbumClearPresenterResult {
+	return &AlbumClearPresenterResult{
+		Res: json,
+	}
+}
+
+func (pre *albumClearPresenter) Response(useResult *usecases.AlbumClearUsecaseResult) (*AlbumClearPresenterResult, error) {
+	json, _ := json.Marshal(map[string]error{"message": useResult.Error})
+	return NewAlbumClearPresenterResult(json), nil
+}

--- a/adapters/presenters/album_clear_test.go
+++ b/adapters/presenters/album_clear_test.go
@@ -1,0 +1,17 @@
+package presenters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Basabi-lab/lms/usecases"
+)
+
+func TestAlbumClearResponse(t *testing.T) {
+	pre := NewAlbumClearPresenter()
+	usecaseResult := usecases.TestAlbumClearUsecaseResult()
+
+	_, err := pre.Response(usecaseResult)
+	assert.NoError(t, err)
+}

--- a/adapters/presenters/artist_clear.go
+++ b/adapters/presenters/artist_clear.go
@@ -1,0 +1,32 @@
+package presenters
+
+import (
+	"encoding/json"
+
+	"github.com/Basabi-lab/lms/usecases"
+)
+
+type ArtistClearPresenterExt interface {
+	Response(useResult *usecases.ArtistClearUsecaseResult) (*ArtistClearPresenterResult, error)
+}
+
+type ArtistClearPresenterResult struct {
+	Res []byte
+}
+
+type artistClearPresenter struct{}
+
+func NewArtistClearPresenter() ArtistClearPresenterExt {
+	return &artistClearPresenter{}
+}
+
+func NewArtistClearPresenterResult(json []byte) *ArtistClearPresenterResult {
+	return &ArtistClearPresenterResult{
+		Res: json,
+	}
+}
+
+func (pre *artistClearPresenter) Response(useResult *usecases.ArtistClearUsecaseResult) (*ArtistClearPresenterResult, error) {
+	json, _ := json.Marshal(map[string]error{"message": useResult.Error})
+	return NewArtistClearPresenterResult(json), nil
+}

--- a/adapters/presenters/artist_clear_test.go
+++ b/adapters/presenters/artist_clear_test.go
@@ -1,0 +1,17 @@
+package presenters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Basabi-lab/lms/usecases"
+)
+
+func TestArtistClearResponse(t *testing.T) {
+	pre := NewArtistClearPresenter()
+	usecaseResult := usecases.TestArtistClearUsecaseResult()
+
+	_, err := pre.Response(usecaseResult)
+	assert.NoError(t, err)
+}

--- a/adapters/presenters/song_clear.go
+++ b/adapters/presenters/song_clear.go
@@ -1,0 +1,32 @@
+package presenters
+
+import (
+	"encoding/json"
+
+	"github.com/Basabi-lab/lms/usecases"
+)
+
+type SongClearPresenterExt interface {
+	Response(useResult *usecases.SongClearUsecaseResult) (*SongClearPresenterResult, error)
+}
+
+type SongClearPresenterResult struct {
+	Res []byte
+}
+
+type songClearPresenter struct{}
+
+func NewSongClearPresenter() SongClearPresenterExt {
+	return &songClearPresenter{}
+}
+
+func NewSongClearPresenterResult(json []byte) *SongClearPresenterResult {
+	return &SongClearPresenterResult{
+		Res: json,
+	}
+}
+
+func (pre *songClearPresenter) Response(useResult *usecases.SongClearUsecaseResult) (*SongClearPresenterResult, error) {
+	json, _ := json.Marshal(map[string]error{"message": useResult.Error})
+	return NewSongClearPresenterResult(json), nil
+}

--- a/adapters/presenters/song_clear_test.go
+++ b/adapters/presenters/song_clear_test.go
@@ -1,0 +1,17 @@
+package presenters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Basabi-lab/lms/usecases"
+)
+
+func TestSongClearResponse(t *testing.T) {
+	pre := NewSongClearPresenter()
+	usecaseResult := usecases.TestSongClearUsecaseResult()
+
+	_, err := pre.Response(usecaseResult)
+	assert.NoError(t, err)
+}

--- a/domains/repositories/album.go
+++ b/domains/repositories/album.go
@@ -6,4 +6,5 @@ type AlbumRepository interface {
 	GetByID(id uint) (*models.Album, error)
 	GetAll() ([]*models.Album, error)
 	Create(cd *models.Album) (uint, error)
+	Clear() error
 }

--- a/domains/repositories/artist.go
+++ b/domains/repositories/artist.go
@@ -6,4 +6,5 @@ type ArtistRepository interface {
 	GetByID(id uint) (*models.Artist, error)
 	GetAll() ([]*models.Artist, error)
 	Create(cd *models.Artist) (uint, error)
+	Clear() error
 }

--- a/domains/repositories/song.go
+++ b/domains/repositories/song.go
@@ -6,4 +6,5 @@ type SongRepository interface {
 	GetByID(id uint) (*models.Song, error)
 	GetAll() ([]*models.Song, error)
 	Create(song *models.Song) (uint, error)
+	Clear() error
 }

--- a/main.go
+++ b/main.go
@@ -37,11 +37,14 @@ func setupRouter(db *gorm.DB) *gin.Engine {
 			agbip,
 			acc,
 			acp,
+			usecases.NewAlbumClearUsecase(ar),
+			presenters.NewAlbumClearPresenter(),
 		)
 
 		api.GET("/album", ac.GetAll)
 		api.GET("/album/:id", ac.GetById)
 		api.POST("/album", ac.Post)
+		api.PATCH("/album/clear", ac.Clear)
 
 		sr := dbs.NewSongMysql(db)
 
@@ -59,11 +62,14 @@ func setupRouter(db *gorm.DB) *gin.Engine {
 			sgbip,
 			scc,
 			scp,
+			usecases.NewSongClearUsecase(sr),
+			presenters.NewSongClearPresenter(),
 		)
 
 		api.GET("/song", sc.GetAll)
 		api.GET("/song/:id", sc.GetById)
 		api.POST("/song", sc.Post)
+		api.PATCH("/song/clear", sc.Clear)
 
 		artistRepo := dbs.NewArtistMysql(db)
 
@@ -81,12 +87,14 @@ func setupRouter(db *gorm.DB) *gin.Engine {
 			artistCreateP,
 			artistGetByIDU,
 			artistGetByIDP,
+			usecases.NewArtistClearUsecase(artistRepo),
+			presenters.NewArtistClearPresenter(),
 		)
 
 		api.GET("/artist", artistCtrl.GetAll)
 		api.GET("/artist/:id", artistCtrl.GetById)
 		api.POST("/artist", artistCtrl.Post)
-
+		api.PATCH("/artist/clear", artistCtrl.Clear)
 	}
 
 	return r

--- a/usecases/album_clear.go
+++ b/usecases/album_clear.go
@@ -1,0 +1,37 @@
+package usecases
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/Basabi-lab/lms/domains/repositories"
+)
+
+type AlbumClearUsecaseResult struct {
+	Error error
+}
+
+type AlbumClearUsecaseExt interface {
+	Clear(c *gin.Context) (*AlbumClearUsecaseResult, error)
+}
+
+type albumClearUsecase struct {
+	repo repositories.AlbumRepository
+}
+
+func NewAlbumClearUsecase(repo repositories.AlbumRepository) AlbumClearUsecaseExt {
+	return &albumClearUsecase{
+		repo: repo,
+	}
+}
+
+func NewAlbumClearUsecaseResult(err error) *AlbumClearUsecaseResult {
+	return &AlbumClearUsecaseResult{
+		Error: err,
+	}
+}
+
+func (use *albumClearUsecase) Clear(c *gin.Context) (*AlbumClearUsecaseResult, error) {
+	err := use.repo.Clear()
+
+	return NewAlbumClearUsecaseResult(err), err
+}

--- a/usecases/album_clear_test.go
+++ b/usecases/album_clear_test.go
@@ -1,0 +1,39 @@
+package usecases
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Basabi-lab/lms/adapters/dbs"
+	"github.com/Basabi-lab/lms/domains/repositories"
+)
+
+type albumClearMysqlMock struct {
+	db *gorm.DB
+	dbs.MixInAlbumMysql
+}
+
+func newAlbumClearMysqlMock(db *gorm.DB) repositories.AlbumRepository {
+	return &albumClearMysqlMock{
+		db: db,
+	}
+}
+
+func (mock *albumClearMysqlMock) Clear() error {
+	return nil
+}
+
+func TestAlbumClearUsecase(t *testing.T) {
+	db := &gorm.DB{}
+	use := NewAlbumClearUsecase(newAlbumClearMysqlMock(db))
+
+	expect := TestAlbumClearUsecaseResult()
+
+	albumsResult, err := use.Clear(&gin.Context{})
+	assert.NoError(t, err)
+
+	assert.Equal(t, expect, albumsResult)
+}

--- a/usecases/artist_clear.go
+++ b/usecases/artist_clear.go
@@ -1,0 +1,37 @@
+package usecases
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/Basabi-lab/lms/domains/repositories"
+)
+
+type ArtistClearUsecaseResult struct {
+	Error error
+}
+
+type ArtistClearUsecaseExt interface {
+	Clear(c *gin.Context) (*ArtistClearUsecaseResult, error)
+}
+
+type artistClearUsecase struct {
+	repo repositories.ArtistRepository
+}
+
+func NewArtistClearUsecase(repo repositories.ArtistRepository) ArtistClearUsecaseExt {
+	return &artistClearUsecase{
+		repo: repo,
+	}
+}
+
+func NewArtistClearUsecaseResult(err error) *ArtistClearUsecaseResult {
+	return &ArtistClearUsecaseResult{
+		Error: err,
+	}
+}
+
+func (use *artistClearUsecase) Clear(c *gin.Context) (*ArtistClearUsecaseResult, error) {
+	err := use.repo.Clear()
+
+	return NewArtistClearUsecaseResult(err), err
+}

--- a/usecases/artist_clear_test.go
+++ b/usecases/artist_clear_test.go
@@ -1,0 +1,39 @@
+package usecases
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Basabi-lab/lms/adapters/dbs"
+	"github.com/Basabi-lab/lms/domains/repositories"
+)
+
+type artistClearMysqlMock struct {
+	db *gorm.DB
+	dbs.MixInArtistMysql
+}
+
+func newArtistClearMysqlMock(db *gorm.DB) repositories.ArtistRepository {
+	return &artistClearMysqlMock{
+		db: db,
+	}
+}
+
+func (mock *artistClearMysqlMock) Clear() error {
+	return nil
+}
+
+func TestArtistClearUsecase(t *testing.T) {
+	db := &gorm.DB{}
+	use := NewArtistClearUsecase(newArtistClearMysqlMock(db))
+
+	expect := TestArtistClearUsecaseResult()
+
+	artistsResult, err := use.Clear(&gin.Context{})
+	assert.NoError(t, err)
+
+	assert.Equal(t, expect, artistsResult)
+}

--- a/usecases/song_clear.go
+++ b/usecases/song_clear.go
@@ -1,0 +1,37 @@
+package usecases
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/Basabi-lab/lms/domains/repositories"
+)
+
+type SongClearUsecaseResult struct {
+	Error error
+}
+
+type SongClearUsecaseExt interface {
+	Clear(c *gin.Context) (*SongClearUsecaseResult, error)
+}
+
+type songClearUsecase struct {
+	repo repositories.SongRepository
+}
+
+func NewSongClearUsecase(repo repositories.SongRepository) SongClearUsecaseExt {
+	return &songClearUsecase{
+		repo: repo,
+	}
+}
+
+func NewSongClearUsecaseResult(err error) *SongClearUsecaseResult {
+	return &SongClearUsecaseResult{
+		Error: err,
+	}
+}
+
+func (use *songClearUsecase) Clear(c *gin.Context) (*SongClearUsecaseResult, error) {
+	err := use.repo.Clear()
+
+	return NewSongClearUsecaseResult(err), err
+}

--- a/usecases/song_clear_test.go
+++ b/usecases/song_clear_test.go
@@ -1,0 +1,39 @@
+package usecases
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Basabi-lab/lms/adapters/dbs"
+	"github.com/Basabi-lab/lms/domains/repositories"
+)
+
+type songClearMysqlMock struct {
+	db *gorm.DB
+	dbs.MixInSongMysql
+}
+
+func newSongClearMysqlMock(db *gorm.DB) repositories.SongRepository {
+	return &songClearMysqlMock{
+		db: db,
+	}
+}
+
+func (mock *songClearMysqlMock) Clear() error {
+	return nil
+}
+
+func TestSongClearUsecase(t *testing.T) {
+	db := &gorm.DB{}
+	use := NewSongClearUsecase(newSongClearMysqlMock(db))
+
+	expect := TestSongClearUsecaseResult()
+
+	songsResult, err := use.Clear(&gin.Context{})
+	assert.NoError(t, err)
+
+	assert.Equal(t, expect, songsResult)
+}

--- a/usecases/test.go
+++ b/usecases/test.go
@@ -20,6 +20,11 @@ func TestAlbumCreateUsecaseResult() *AlbumCreateUsecaseResult {
 	return NewAlbumCreateUsecaseResult(id)
 }
 
+func TestAlbumClearUsecaseResult() *AlbumClearUsecaseResult {
+	var err error = nil
+	return NewAlbumClearUsecaseResult(err)
+}
+
 func TestSongAllUsecaseResult() *SongAllUsecaseResult {
 	song := models.TestSongData()
 	songs := []*models.Song{song, song}
@@ -34,6 +39,11 @@ func TestSongGetByIDUsecaseResult() *SongGetByIDUsecaseResult {
 func TestSongCreateUsecaseResult() *SongCreateUsecaseResult {
 	id := uint(0)
 	return NewSongCreateUsecaseResult(id)
+}
+
+func TestSongClearUsecaseResult() *SongClearUsecaseResult {
+	var err error = nil
+	return NewSongClearUsecaseResult(err)
 }
 
 func TestArtistAllUsecaseResult() *ArtistAllUsecaseResult {
@@ -51,4 +61,9 @@ func TestArtistGetByIDUsecaseResult() *ArtistGetByIDUsecaseResult {
 func TestArtistCreateUsecaseResult() *ArtistCreateUsecaseResult {
 	id := uint(0)
 	return NewArtistCreateUsecaseResult(id)
+}
+
+func TestArtistClearUsecaseResult() *ArtistClearUsecaseResult {
+	var err error = nil
+	return NewArtistClearUsecaseResult(err)
 }


### PR DESCRIPTION
album,artist,songに指定したtableのデータをsoft delete(deleted_atを記入)する機能を持つclear APIを実装した

close #34 