### PR TITLE
Fix post API実行時に、modelのデータ全部返すように修正

### DIFF
--- a/adapters/controllers/album.go
+++ b/adapters/controllers/album.go
@@ -99,13 +99,19 @@ func (h *albumController) Post(c *gin.Context) {
 		return
 	}
 
-	pRes, err := h.albumCreatePre.Response(cRes)
+	pRes, err := h.albumCreatePre.ToByteList(cRes)
 	if err != nil {
 		ResponseError(c, err)
 		return
 	}
 
-	c.JSON(200, pRes.Res)
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.WriteHeader(200)
+	_, err = c.Writer.Write(pRes.JsonByteList)
+	if err != nil {
+		ResponseError(c, err)
+		return
+	}
 }
 
 func (h *albumController) Clear(c *gin.Context) {

--- a/adapters/controllers/artist.go
+++ b/adapters/controllers/artist.go
@@ -99,13 +99,19 @@ func (h *artistController) Post(c *gin.Context) {
 		return
 	}
 
-	pRes, err := h.artistCreatePre.Response(cRes)
+	pRes, err := h.artistCreatePre.ToByteList(cRes)
 	if err != nil {
 		ResponseError(c, err)
 		return
 	}
 
-	c.JSON(200, pRes.Res)
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.WriteHeader(200)
+	_, err = c.Writer.Write(pRes.JsonByteList)
+	if err != nil {
+		ResponseError(c, err)
+		return
+	}
 }
 
 func (h *artistController) Clear(c *gin.Context) {

--- a/adapters/controllers/song.go
+++ b/adapters/controllers/song.go
@@ -99,13 +99,19 @@ func (h *songController) Post(c *gin.Context) {
 		return
 	}
 
-	pRes, err := h.songCreatePre.Response(cRes)
+	pRes, err := h.songCreatePre.ToByteList(cRes)
 	if err != nil {
 		ResponseError(c, err)
 		return
 	}
 
-	c.JSON(200, pRes.Res)
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.WriteHeader(200)
+	_, err = c.Writer.Write(pRes.JsonByteList)
+	if err != nil {
+		ResponseError(c, err)
+		return
+	}
 }
 
 func (h *songController) Clear(c *gin.Context) {

--- a/adapters/presenters/album_create.go
+++ b/adapters/presenters/album_create.go
@@ -1,17 +1,17 @@
 package presenters
 
 import (
-	"github.com/gin-gonic/gin"
+	"encoding/json"
 
 	"github.com/Basabi-lab/lms/usecases"
 )
 
 type AlbumCreatePresenterExt interface {
-	Response(useResult *usecases.AlbumCreateUsecaseResult) (*AlbumCreatePresenterResult, error)
+	ToByteList(useResult *usecases.AlbumCreateUsecaseResult) (*AlbumCreatePresenterResult, error)
 }
 
 type AlbumCreatePresenterResult struct {
-	Res *gin.H
+	JsonByteList []byte
 }
 
 type albumCreatePresenter struct{}
@@ -20,14 +20,13 @@ func NewAlbumCreatePresenter() AlbumCreatePresenterExt {
 	return &albumCreatePresenter{}
 }
 
-func NewAlbumCreatePresenterResult(res *gin.H) *AlbumCreatePresenterResult {
+func NewAlbumCreatePresenterResult(json []byte) *AlbumCreatePresenterResult {
 	return &AlbumCreatePresenterResult{
-		Res: res,
+		JsonByteList: json,
 	}
 }
 
-func (pre *albumCreatePresenter) Response(useResult *usecases.AlbumCreateUsecaseResult) (*AlbumCreatePresenterResult, error) {
-	res := &gin.H{"message": "success", "id": useResult.ID}
-
-	return NewAlbumCreatePresenterResult(res), nil
+func (pre *albumCreatePresenter) ToByteList(useResult *usecases.AlbumCreateUsecaseResult) (*AlbumCreatePresenterResult, error) {
+	json, _ := json.Marshal(useResult.Album)
+	return NewAlbumCreatePresenterResult(json), nil
 }

--- a/adapters/presenters/album_create_test.go
+++ b/adapters/presenters/album_create_test.go
@@ -11,9 +11,7 @@ import (
 func TestAlbumCreateResponse(t *testing.T) {
 	pre := NewAlbumCreatePresenter()
 	usecaseResult := usecases.TestAlbumCreateUsecaseResult()
-	expect := TestAlbumCreatePresenterResult()
 
-	ret, err := pre.Response(usecaseResult)
+	_, err := pre.ToByteList(usecaseResult)
 	assert.NoError(t, err)
-	assert.Equal(t, expect, ret)
 }

--- a/adapters/presenters/artist_create.go
+++ b/adapters/presenters/artist_create.go
@@ -1,17 +1,17 @@
 package presenters
 
 import (
-	"github.com/gin-gonic/gin"
+	"encoding/json"
 
 	"github.com/Basabi-lab/lms/usecases"
 )
 
 type ArtistCreatePresenterExt interface {
-	Response(useResult *usecases.ArtistCreateUsecaseResult) (*ArtistCreatePresenterResult, error)
+	ToByteList(useResult *usecases.ArtistCreateUsecaseResult) (*ArtistCreatePresenterResult, error)
 }
 
 type ArtistCreatePresenterResult struct {
-	Res *gin.H
+	JsonByteList []byte
 }
 
 type artistCreatePresenter struct{}
@@ -20,14 +20,14 @@ func NewArtistCreatePresenter() ArtistCreatePresenterExt {
 	return &artistCreatePresenter{}
 }
 
-func NewArtistCreatePresenterResult(res *gin.H) *ArtistCreatePresenterResult {
+func NewArtistCreatePresenterResult(json []byte) *ArtistCreatePresenterResult {
 	return &ArtistCreatePresenterResult{
-		Res: res,
+		JsonByteList: json,
 	}
 }
 
-func (use *artistCreatePresenter) Response(useResult *usecases.ArtistCreateUsecaseResult) (*ArtistCreatePresenterResult, error) {
-	res := &gin.H{"message": "success", "id": useResult.ID}
+func (use *artistCreatePresenter) ToByteList(useResult *usecases.ArtistCreateUsecaseResult) (*ArtistCreatePresenterResult, error) {
+	json, _ := json.Marshal(useResult.Artist)
 
-	return NewArtistCreatePresenterResult(res), nil
+	return NewArtistCreatePresenterResult(json), nil
 }

--- a/adapters/presenters/artist_create_test.go
+++ b/adapters/presenters/artist_create_test.go
@@ -11,9 +11,7 @@ import (
 func TestArtistCreateResponse(t *testing.T) {
 	pre := NewArtistCreatePresenter()
 	usecaseResult := usecases.TestArtistCreateUsecaseResult()
-	expect := TestArtistCreatePresenterResult()
 
-	ret, err := pre.Response(usecaseResult)
+	_, err := pre.ToByteList(usecaseResult)
 	assert.NoError(t, err)
-	assert.Equal(t, expect, ret)
 }

--- a/adapters/presenters/song_create.go
+++ b/adapters/presenters/song_create.go
@@ -1,17 +1,17 @@
 package presenters
 
 import (
-	"github.com/gin-gonic/gin"
+	"encoding/json"
 
 	"github.com/Basabi-lab/lms/usecases"
 )
 
 type SongCreatePresenterExt interface {
-	Response(useResult *usecases.SongCreateUsecaseResult) (*SongCreatePresenterResult, error)
+	ToByteList(useResult *usecases.SongCreateUsecaseResult) (*SongCreatePresenterResult, error)
 }
 
 type SongCreatePresenterResult struct {
-	Res *gin.H
+	JsonByteList []byte
 }
 
 type songCreatePresenter struct{}
@@ -20,14 +20,13 @@ func NewSongCreatePresenter() SongCreatePresenterExt {
 	return &songCreatePresenter{}
 }
 
-func NewSongCreatePresenterResult(res *gin.H) *SongCreatePresenterResult {
+func NewSongCreatePresenterResult(json []byte) *SongCreatePresenterResult {
 	return &SongCreatePresenterResult{
-		Res: res,
+		JsonByteList: json,
 	}
 }
 
-func (pre *songCreatePresenter) Response(useResult *usecases.SongCreateUsecaseResult) (*SongCreatePresenterResult, error) {
-	res := &gin.H{"message": "success", "id": useResult.ID}
-
-	return NewSongCreatePresenterResult(res), nil
+func (pre *songCreatePresenter) ToByteList(useResult *usecases.SongCreateUsecaseResult) (*SongCreatePresenterResult, error) {
+	json, _ := json.Marshal(useResult.Song)
+	return NewSongCreatePresenterResult(json), nil
 }

--- a/adapters/presenters/song_create_test.go
+++ b/adapters/presenters/song_create_test.go
@@ -11,9 +11,7 @@ import (
 func TestSongCreateResponse(t *testing.T) {
 	pre := NewSongCreatePresenter()
 	usecaseResult := usecases.TestSongCreateUsecaseResult()
-	expect := TestSongCreatePresenterResult()
 
-	ret, err := pre.Response(usecaseResult)
+	_, err := pre.ToByteList(usecaseResult)
 	assert.NoError(t, err)
-	assert.Equal(t, expect, ret)
 }

--- a/adapters/presenters/test.go
+++ b/adapters/presenters/test.go
@@ -1,17 +1,1 @@
 package presenters
-
-import (
-	"github.com/gin-gonic/gin"
-)
-
-func TestAlbumCreatePresenterResult() *AlbumCreatePresenterResult {
-	return NewAlbumCreatePresenterResult(&gin.H{"message": "success", "id": uint(0)})
-}
-
-func TestSongCreatePresenterResult() *SongCreatePresenterResult {
-	return NewSongCreatePresenterResult(&gin.H{"message": "success", "id": uint(0)})
-}
-
-func TestArtistCreatePresenterResult() *ArtistCreatePresenterResult {
-	return NewArtistCreatePresenterResult(&gin.H{"message": "success", "id": uint(0)})
-}

--- a/domains/models/artist.go
+++ b/domains/models/artist.go
@@ -3,6 +3,6 @@ package models
 type Artist struct {
 	Model
 	Album     []*Album `json:"album"`
-	Name      string   `json:"title"`
+	Name      string   `json:"name"`
 	Biography string   `json:"biography"`
 }

--- a/usecases/album_create.go
+++ b/usecases/album_create.go
@@ -8,7 +8,7 @@ import (
 )
 
 type AlbumCreateUsecaseResult struct {
-	ID uint
+	Album *models.Album
 }
 
 type AlbumCreateUsecaseExt interface {
@@ -25,19 +25,20 @@ func NewAlbumCreateUsecase(repo repositories.AlbumRepository) AlbumCreateUsecase
 	}
 }
 
-func NewAlbumCreateUsecaseResult(id uint) *AlbumCreateUsecaseResult {
+func NewAlbumCreateUsecaseResult(album *models.Album) *AlbumCreateUsecaseResult {
 	return &AlbumCreateUsecaseResult{
-		ID: id,
+		Album: album,
 	}
 }
 
 func (use *albumCreateUsecase) Create(c *gin.Context) (*AlbumCreateUsecaseResult, error) {
-	var json models.Album
-	err := c.ShouldBindJSON(&json)
+	var album *models.Album
+	err := c.ShouldBindJSON(&album)
 	if err != nil {
 		return nil, err
 	}
-	id, err := use.repo.Create(&json)
+	id, err := use.repo.Create(album)
+	album.ID = id
 
-	return NewAlbumCreateUsecaseResult(id), err
+	return NewAlbumCreateUsecaseResult(album), err
 }

--- a/usecases/album_create_test.go
+++ b/usecases/album_create_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
@@ -21,14 +22,14 @@ type albumCreateMysqlMock struct {
 	dbs.MixInAlbumMysql
 }
 
+func (mock *albumCreateMysqlMock) Create(cd *models.Album) (uint, error) {
+	return 0, nil
+}
+
 func newAlbumCreateMysqlMock(db *gorm.DB) repositories.AlbumRepository {
 	return &albumCreateMysqlMock{
 		db: db,
 	}
-}
-
-func (mock *albumCreateMysqlMock) Create(cd *models.Album) (uint, error) {
-	return 0, nil
 }
 
 func TestAlbumCreateUsecase(t *testing.T) {
@@ -36,12 +37,15 @@ func TestAlbumCreateUsecase(t *testing.T) {
 	use := NewAlbumCreateUsecase(newAlbumCreateMysqlMock(db))
 
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	c.Request, _ = http.NewRequest("POST", "/", bytes.NewBufferString("{\"title\":\"bar\", \"genre\":\"foo\", \"year\":2000}"))
+	c.Request, _ = http.NewRequest("POST", "/", bytes.NewBufferString("{\"title\":\"Album title\", \"artist_id\":1}"))
 	c.Request.Header.Add("Content-Type", binding.MIMEJSON)
 
 	result, err := use.Create(c)
 	assert.NoError(t, err)
 
 	expect := TestAlbumCreateUsecaseResult()
+	expect.Album.CreatedAt = time.Time{}
+	expect.Album.UpdatedAt = time.Time{}
+	expect.Album.DeletedAt = nil
 	assert.Equal(t, expect, result)
 }

--- a/usecases/artist_create.go
+++ b/usecases/artist_create.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ArtistCreateUsecaseResult struct {
-	ID uint
+	Artist *models.Artist
 }
 
 type ArtistCreateUsecaseExt interface {
@@ -25,19 +25,20 @@ func NewArtistCreateUsecase(repo repositories.ArtistRepository) ArtistCreateUsec
 	}
 }
 
-func NewArtistCreateUsecaseResult(id uint) *ArtistCreateUsecaseResult {
+func NewArtistCreateUsecaseResult(artist *models.Artist) *ArtistCreateUsecaseResult {
 	return &ArtistCreateUsecaseResult{
-		ID: id,
+		Artist: artist,
 	}
 }
 
 func (use *artistCreateUsecase) Create(c *gin.Context) (*ArtistCreateUsecaseResult, error) {
-	var json models.Artist
-	err := c.ShouldBindJSON(&json)
+	var artist *models.Artist
+	err := c.ShouldBindJSON(&artist)
 	if err != nil {
 		return nil, err
 	}
-	id, err := use.repo.Create(&json)
+	id, err := use.repo.Create(artist)
+	artist.ID = id
 
-	return NewArtistCreateUsecaseResult(id), err
+	return NewArtistCreateUsecaseResult(artist), err
 }

--- a/usecases/artist_create_test.go
+++ b/usecases/artist_create_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
@@ -36,12 +37,15 @@ func TestArtistCreateUsecase(t *testing.T) {
 	use := NewArtistCreateUsecase(newArtistCreateMysqlMock(db))
 
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	c.Request, _ = http.NewRequest("POST", "/", bytes.NewBufferString("{\"album_id\": 1, \"name\":\"artist name\", \"biography\":\"artist biography\"}"))
+	c.Request, _ = http.NewRequest("POST", "/", bytes.NewBufferString("{\"name\":\"Artist name\", \"biography\":\"Artist biography\"}"))
 	c.Request.Header.Add("Content-Type", binding.MIMEJSON)
 
 	result, err := use.Create(c)
 	assert.NoError(t, err)
 
 	expect := TestArtistCreateUsecaseResult()
+	expect.Artist.CreatedAt = time.Time{}
+	expect.Artist.UpdatedAt = time.Time{}
+	expect.Artist.DeletedAt = nil
 	assert.Equal(t, expect, result)
 }

--- a/usecases/song_create.go
+++ b/usecases/song_create.go
@@ -8,7 +8,7 @@ import (
 )
 
 type SongCreateUsecaseResult struct {
-	ID uint
+	Song *models.Song
 }
 
 type SongCreateUsecaseExt interface {
@@ -25,19 +25,20 @@ func NewSongCreateUsecase(repo repositories.SongRepository) SongCreateUsecaseExt
 	}
 }
 
-func NewSongCreateUsecaseResult(id uint) *SongCreateUsecaseResult {
+func NewSongCreateUsecaseResult(song *models.Song) *SongCreateUsecaseResult {
 	return &SongCreateUsecaseResult{
-		ID: id,
+		Song: song,
 	}
 }
 
 func (use *songCreateUsecase) Create(c *gin.Context) (*SongCreateUsecaseResult, error) {
-	var json models.Song
-	err := c.ShouldBindJSON(&json)
+	var song *models.Song
+	err := c.ShouldBindJSON(&song)
 	if err != nil {
 		return nil, err
 	}
-	id, err := use.repo.Create(&json)
+	id, err := use.repo.Create(song)
+	song.ID = id
 
-	return NewSongCreateUsecaseResult(id), err
+	return NewSongCreateUsecaseResult(song), err
 }

--- a/usecases/song_create_test.go
+++ b/usecases/song_create_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
@@ -38,14 +39,14 @@ func TestSongCreateUsecase(t *testing.T) {
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 	json := `
 		{
-			"title":"song title",
-			"genre":"song genre",
+			"title":"Song Title",
+			"genre":"Song Genre",
 			"year":2000,
 			"artist_id":1,
 			"album_id":1,
 			"track":1,
-			"album_num": 1,
-			"dir":"/home/sample/song/dir"
+			"disc": 1,
+			"path":"/home/sample/Music/dir"
 		}
 	`
 	c.Request, _ = http.NewRequest("POST", "/", bytes.NewBufferString(json))
@@ -55,5 +56,8 @@ func TestSongCreateUsecase(t *testing.T) {
 	assert.NoError(t, err)
 
 	expect := TestSongCreateUsecaseResult()
+	expect.Song.CreatedAt = time.Time{}
+	expect.Song.UpdatedAt = time.Time{}
+	expect.Song.DeletedAt = nil
 	assert.Equal(t, expect, result)
 }

--- a/usecases/test.go
+++ b/usecases/test.go
@@ -16,8 +16,8 @@ func TestAlbumGetByIDUsecaseResult() *AlbumGetByIDUsecaseResult {
 }
 
 func TestAlbumCreateUsecaseResult() *AlbumCreateUsecaseResult {
-	id := uint(0)
-	return NewAlbumCreateUsecaseResult(id)
+	album := models.TestAlbumData()
+	return NewAlbumCreateUsecaseResult(album)
 }
 
 func TestAlbumClearUsecaseResult() *AlbumClearUsecaseResult {
@@ -37,8 +37,8 @@ func TestSongGetByIDUsecaseResult() *SongGetByIDUsecaseResult {
 }
 
 func TestSongCreateUsecaseResult() *SongCreateUsecaseResult {
-	id := uint(0)
-	return NewSongCreateUsecaseResult(id)
+	song := models.TestSongData()
+	return NewSongCreateUsecaseResult(song)
 }
 
 func TestSongClearUsecaseResult() *SongClearUsecaseResult {
@@ -59,8 +59,8 @@ func TestArtistGetByIDUsecaseResult() *ArtistGetByIDUsecaseResult {
 }
 
 func TestArtistCreateUsecaseResult() *ArtistCreateUsecaseResult {
-	id := uint(0)
-	return NewArtistCreateUsecaseResult(id)
+	artist := models.TestArtistData()
+	return NewArtistCreateUsecaseResult(artist)
 }
 
 func TestArtistClearUsecaseResult() *ArtistClearUsecaseResult {


### PR DESCRIPTION
もとは、IDだけを返すようにしていたが、
色々と面倒そうだったので、modelのメンバ全部返すように修正

close #33 